### PR TITLE
Update SETUP.md

### DIFF
--- a/SETUP.md
+++ b/SETUP.md
@@ -2,7 +2,7 @@
 
 ## 1100CC & nodegoat
 
-Make sure 1100CC is configured or your server and a new SITE named 'nodegoat' has been added and setup (see the [1100CC SETUP](https://github.com/LAB1100/1100CC/blob/master/SETUP.md) instructions).
+Make sure 1100CC is configured or your server and a new SITE named 'nodegoat' has been added and setup. This is described at [1100CC SETUP](https://github.com/LAB1100/1100CC/blob/master/SETUP.md) instructions. Note that you shouldn't follow the instructions about the default settings of the exemplary site provided there. In particular, do not inject SITE_\*.sql (renamed as nodegoat_\*.sql) in your database.
 
 Update the new nodegoat setup with this repository:
 1. Overwrite the new `./APP/nodegoat` and  `./APP/SETTINGS/nodegoat` directories in your 1100CC directory with the `./APP/nodegoat` and `./APP/SETTINGS/nodegoat` directories from this repository.


### PR DESCRIPTION
Make it clear that some instructions in 1100CC SETUP must be ignored to install nodegoat.